### PR TITLE
Handle Non-Image Buildpacks

### DIFF
--- a/.github/workflows/update-apache-tomcat.yml
+++ b/.github/workflows/update-apache-tomcat.yml
@@ -62,7 +62,7 @@ jobs:
                 NEW_VERSION=$(crane ls "${DEPENDENCY}" | grep -v latest | sort -V | tail -n 1)
 
                 if [[ -e builder.toml ]]; then
-                  OLD_VERSION=$(yj -tj < builder.toml | jq -r ".buildpacks[].image | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
+                  OLD_VERSION=$(yj -tj < builder.toml | jq -r ".buildpacks[].image | select( . != null ) | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
 
                   update-package-dependency \
                     --builder-toml builder.toml \
@@ -71,7 +71,7 @@ jobs:
 
                   git add builder.toml
                 elif [[ -e package.toml ]]; then
-                  OLD_VERSION=$(yj -tj < package.toml | jq -r ".dependencies[].image | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
+                  OLD_VERSION=$(yj -tj < package.toml | jq -r ".dependencies[].image | select( . != null ) | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
 
                   update-package-dependency \
                     --buildpack-toml buildpack.toml \

--- a/.github/workflows/update-azul-zulu.yml
+++ b/.github/workflows/update-azul-zulu.yml
@@ -62,7 +62,7 @@ jobs:
                 NEW_VERSION=$(crane ls "${DEPENDENCY}" | grep -v latest | sort -V | tail -n 1)
 
                 if [[ -e builder.toml ]]; then
-                  OLD_VERSION=$(yj -tj < builder.toml | jq -r ".buildpacks[].image | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
+                  OLD_VERSION=$(yj -tj < builder.toml | jq -r ".buildpacks[].image | select( . != null ) | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
 
                   update-package-dependency \
                     --builder-toml builder.toml \
@@ -71,7 +71,7 @@ jobs:
 
                   git add builder.toml
                 elif [[ -e package.toml ]]; then
-                  OLD_VERSION=$(yj -tj < package.toml | jq -r ".dependencies[].image | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
+                  OLD_VERSION=$(yj -tj < package.toml | jq -r ".dependencies[].image | select( . != null ) | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
 
                   update-package-dependency \
                     --buildpack-toml buildpack.toml \

--- a/.github/workflows/update-azure-application-insights.yml
+++ b/.github/workflows/update-azure-application-insights.yml
@@ -62,7 +62,7 @@ jobs:
                 NEW_VERSION=$(crane ls "${DEPENDENCY}" | grep -v latest | sort -V | tail -n 1)
 
                 if [[ -e builder.toml ]]; then
-                  OLD_VERSION=$(yj -tj < builder.toml | jq -r ".buildpacks[].image | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
+                  OLD_VERSION=$(yj -tj < builder.toml | jq -r ".buildpacks[].image | select( . != null ) | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
 
                   update-package-dependency \
                     --builder-toml builder.toml \
@@ -71,7 +71,7 @@ jobs:
 
                   git add builder.toml
                 elif [[ -e package.toml ]]; then
-                  OLD_VERSION=$(yj -tj < package.toml | jq -r ".dependencies[].image | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
+                  OLD_VERSION=$(yj -tj < package.toml | jq -r ".dependencies[].image | select( . != null ) | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
 
                   update-package-dependency \
                     --buildpack-toml buildpack.toml \

--- a/.github/workflows/update-debug.yml
+++ b/.github/workflows/update-debug.yml
@@ -62,7 +62,7 @@ jobs:
                 NEW_VERSION=$(crane ls "${DEPENDENCY}" | grep -v latest | sort -V | tail -n 1)
 
                 if [[ -e builder.toml ]]; then
-                  OLD_VERSION=$(yj -tj < builder.toml | jq -r ".buildpacks[].image | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
+                  OLD_VERSION=$(yj -tj < builder.toml | jq -r ".buildpacks[].image | select( . != null ) | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
 
                   update-package-dependency \
                     --builder-toml builder.toml \
@@ -71,7 +71,7 @@ jobs:
 
                   git add builder.toml
                 elif [[ -e package.toml ]]; then
-                  OLD_VERSION=$(yj -tj < package.toml | jq -r ".dependencies[].image | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
+                  OLD_VERSION=$(yj -tj < package.toml | jq -r ".dependencies[].image | select( . != null ) | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
 
                   update-package-dependency \
                     --buildpack-toml buildpack.toml \

--- a/.github/workflows/update-dist-zip.yml
+++ b/.github/workflows/update-dist-zip.yml
@@ -62,7 +62,7 @@ jobs:
                 NEW_VERSION=$(crane ls "${DEPENDENCY}" | grep -v latest | sort -V | tail -n 1)
 
                 if [[ -e builder.toml ]]; then
-                  OLD_VERSION=$(yj -tj < builder.toml | jq -r ".buildpacks[].image | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
+                  OLD_VERSION=$(yj -tj < builder.toml | jq -r ".buildpacks[].image | select( . != null ) | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
 
                   update-package-dependency \
                     --builder-toml builder.toml \
@@ -71,7 +71,7 @@ jobs:
 
                   git add builder.toml
                 elif [[ -e package.toml ]]; then
-                  OLD_VERSION=$(yj -tj < package.toml | jq -r ".dependencies[].image | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
+                  OLD_VERSION=$(yj -tj < package.toml | jq -r ".dependencies[].image | select( . != null ) | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
 
                   update-package-dependency \
                     --buildpack-toml buildpack.toml \

--- a/.github/workflows/update-encrypt-at-rest.yml
+++ b/.github/workflows/update-encrypt-at-rest.yml
@@ -62,7 +62,7 @@ jobs:
                 NEW_VERSION=$(crane ls "${DEPENDENCY}" | grep -v latest | sort -V | tail -n 1)
 
                 if [[ -e builder.toml ]]; then
-                  OLD_VERSION=$(yj -tj < builder.toml | jq -r ".buildpacks[].image | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
+                  OLD_VERSION=$(yj -tj < builder.toml | jq -r ".buildpacks[].image | select( . != null ) | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
 
                   update-package-dependency \
                     --builder-toml builder.toml \
@@ -71,7 +71,7 @@ jobs:
 
                   git add builder.toml
                 elif [[ -e package.toml ]]; then
-                  OLD_VERSION=$(yj -tj < package.toml | jq -r ".dependencies[].image | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
+                  OLD_VERSION=$(yj -tj < package.toml | jq -r ".dependencies[].image | select( . != null ) | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
 
                   update-package-dependency \
                     --buildpack-toml buildpack.toml \

--- a/.github/workflows/update-environment-variables.yml
+++ b/.github/workflows/update-environment-variables.yml
@@ -62,7 +62,7 @@ jobs:
                 NEW_VERSION=$(crane ls "${DEPENDENCY}" | grep -v latest | sort -V | tail -n 1)
 
                 if [[ -e builder.toml ]]; then
-                  OLD_VERSION=$(yj -tj < builder.toml | jq -r ".buildpacks[].image | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
+                  OLD_VERSION=$(yj -tj < builder.toml | jq -r ".buildpacks[].image | select( . != null ) | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
 
                   update-package-dependency \
                     --builder-toml builder.toml \
@@ -71,7 +71,7 @@ jobs:
 
                   git add builder.toml
                 elif [[ -e package.toml ]]; then
-                  OLD_VERSION=$(yj -tj < package.toml | jq -r ".dependencies[].image | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
+                  OLD_VERSION=$(yj -tj < package.toml | jq -r ".dependencies[].image | select( . != null ) | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
 
                   update-package-dependency \
                     --buildpack-toml buildpack.toml \

--- a/.github/workflows/update-executable-jar.yml
+++ b/.github/workflows/update-executable-jar.yml
@@ -62,7 +62,7 @@ jobs:
                 NEW_VERSION=$(crane ls "${DEPENDENCY}" | grep -v latest | sort -V | tail -n 1)
 
                 if [[ -e builder.toml ]]; then
-                  OLD_VERSION=$(yj -tj < builder.toml | jq -r ".buildpacks[].image | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
+                  OLD_VERSION=$(yj -tj < builder.toml | jq -r ".buildpacks[].image | select( . != null ) | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
 
                   update-package-dependency \
                     --builder-toml builder.toml \
@@ -71,7 +71,7 @@ jobs:
 
                   git add builder.toml
                 elif [[ -e package.toml ]]; then
-                  OLD_VERSION=$(yj -tj < package.toml | jq -r ".dependencies[].image | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
+                  OLD_VERSION=$(yj -tj < package.toml | jq -r ".dependencies[].image | select( . != null ) | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
 
                   update-package-dependency \
                     --buildpack-toml buildpack.toml \

--- a/.github/workflows/update-gradle.yml
+++ b/.github/workflows/update-gradle.yml
@@ -62,7 +62,7 @@ jobs:
                 NEW_VERSION=$(crane ls "${DEPENDENCY}" | grep -v latest | sort -V | tail -n 1)
 
                 if [[ -e builder.toml ]]; then
-                  OLD_VERSION=$(yj -tj < builder.toml | jq -r ".buildpacks[].image | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
+                  OLD_VERSION=$(yj -tj < builder.toml | jq -r ".buildpacks[].image | select( . != null ) | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
 
                   update-package-dependency \
                     --builder-toml builder.toml \
@@ -71,7 +71,7 @@ jobs:
 
                   git add builder.toml
                 elif [[ -e package.toml ]]; then
-                  OLD_VERSION=$(yj -tj < package.toml | jq -r ".dependencies[].image | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
+                  OLD_VERSION=$(yj -tj < package.toml | jq -r ".dependencies[].image | select( . != null ) | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
 
                   update-package-dependency \
                     --buildpack-toml buildpack.toml \

--- a/.github/workflows/update-image-labels.yml
+++ b/.github/workflows/update-image-labels.yml
@@ -62,7 +62,7 @@ jobs:
                 NEW_VERSION=$(crane ls "${DEPENDENCY}" | grep -v latest | sort -V | tail -n 1)
 
                 if [[ -e builder.toml ]]; then
-                  OLD_VERSION=$(yj -tj < builder.toml | jq -r ".buildpacks[].image | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
+                  OLD_VERSION=$(yj -tj < builder.toml | jq -r ".buildpacks[].image | select( . != null ) | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
 
                   update-package-dependency \
                     --builder-toml builder.toml \
@@ -71,7 +71,7 @@ jobs:
 
                   git add builder.toml
                 elif [[ -e package.toml ]]; then
-                  OLD_VERSION=$(yj -tj < package.toml | jq -r ".dependencies[].image | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
+                  OLD_VERSION=$(yj -tj < package.toml | jq -r ".dependencies[].image | select( . != null ) | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
 
                   update-package-dependency \
                     --buildpack-toml buildpack.toml \

--- a/.github/workflows/update-jmx.yml
+++ b/.github/workflows/update-jmx.yml
@@ -62,7 +62,7 @@ jobs:
                 NEW_VERSION=$(crane ls "${DEPENDENCY}" | grep -v latest | sort -V | tail -n 1)
 
                 if [[ -e builder.toml ]]; then
-                  OLD_VERSION=$(yj -tj < builder.toml | jq -r ".buildpacks[].image | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
+                  OLD_VERSION=$(yj -tj < builder.toml | jq -r ".buildpacks[].image | select( . != null ) | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
 
                   update-package-dependency \
                     --builder-toml builder.toml \
@@ -71,7 +71,7 @@ jobs:
 
                   git add builder.toml
                 elif [[ -e package.toml ]]; then
-                  OLD_VERSION=$(yj -tj < package.toml | jq -r ".dependencies[].image | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
+                  OLD_VERSION=$(yj -tj < package.toml | jq -r ".dependencies[].image | select( . != null ) | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
 
                   update-package-dependency \
                     --buildpack-toml buildpack.toml \

--- a/.github/workflows/update-leiningen.yml
+++ b/.github/workflows/update-leiningen.yml
@@ -62,7 +62,7 @@ jobs:
                 NEW_VERSION=$(crane ls "${DEPENDENCY}" | grep -v latest | sort -V | tail -n 1)
 
                 if [[ -e builder.toml ]]; then
-                  OLD_VERSION=$(yj -tj < builder.toml | jq -r ".buildpacks[].image | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
+                  OLD_VERSION=$(yj -tj < builder.toml | jq -r ".buildpacks[].image | select( . != null ) | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
 
                   update-package-dependency \
                     --builder-toml builder.toml \
@@ -71,7 +71,7 @@ jobs:
 
                   git add builder.toml
                 elif [[ -e package.toml ]]; then
-                  OLD_VERSION=$(yj -tj < package.toml | jq -r ".dependencies[].image | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
+                  OLD_VERSION=$(yj -tj < package.toml | jq -r ".dependencies[].image | select( . != null ) | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
 
                   update-package-dependency \
                     --buildpack-toml buildpack.toml \

--- a/.github/workflows/update-maven.yml
+++ b/.github/workflows/update-maven.yml
@@ -62,7 +62,7 @@ jobs:
                 NEW_VERSION=$(crane ls "${DEPENDENCY}" | grep -v latest | sort -V | tail -n 1)
 
                 if [[ -e builder.toml ]]; then
-                  OLD_VERSION=$(yj -tj < builder.toml | jq -r ".buildpacks[].image | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
+                  OLD_VERSION=$(yj -tj < builder.toml | jq -r ".buildpacks[].image | select( . != null ) | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
 
                   update-package-dependency \
                     --builder-toml builder.toml \
@@ -71,7 +71,7 @@ jobs:
 
                   git add builder.toml
                 elif [[ -e package.toml ]]; then
-                  OLD_VERSION=$(yj -tj < package.toml | jq -r ".dependencies[].image | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
+                  OLD_VERSION=$(yj -tj < package.toml | jq -r ".dependencies[].image | select( . != null ) | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
 
                   update-package-dependency \
                     --buildpack-toml buildpack.toml \

--- a/.github/workflows/update-procfile.yml
+++ b/.github/workflows/update-procfile.yml
@@ -62,7 +62,7 @@ jobs:
                 NEW_VERSION=$(crane ls "${DEPENDENCY}" | grep -v latest | sort -V | tail -n 1)
 
                 if [[ -e builder.toml ]]; then
-                  OLD_VERSION=$(yj -tj < builder.toml | jq -r ".buildpacks[].image | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
+                  OLD_VERSION=$(yj -tj < builder.toml | jq -r ".buildpacks[].image | select( . != null ) | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
 
                   update-package-dependency \
                     --builder-toml builder.toml \
@@ -71,7 +71,7 @@ jobs:
 
                   git add builder.toml
                 elif [[ -e package.toml ]]; then
-                  OLD_VERSION=$(yj -tj < package.toml | jq -r ".dependencies[].image | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
+                  OLD_VERSION=$(yj -tj < package.toml | jq -r ".dependencies[].image | select( . != null ) | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
 
                   update-package-dependency \
                     --buildpack-toml buildpack.toml \

--- a/.github/workflows/update-sbt.yml
+++ b/.github/workflows/update-sbt.yml
@@ -62,7 +62,7 @@ jobs:
                 NEW_VERSION=$(crane ls "${DEPENDENCY}" | grep -v latest | sort -V | tail -n 1)
 
                 if [[ -e builder.toml ]]; then
-                  OLD_VERSION=$(yj -tj < builder.toml | jq -r ".buildpacks[].image | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
+                  OLD_VERSION=$(yj -tj < builder.toml | jq -r ".buildpacks[].image | select( . != null ) | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
 
                   update-package-dependency \
                     --builder-toml builder.toml \
@@ -71,7 +71,7 @@ jobs:
 
                   git add builder.toml
                 elif [[ -e package.toml ]]; then
-                  OLD_VERSION=$(yj -tj < package.toml | jq -r ".dependencies[].image | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
+                  OLD_VERSION=$(yj -tj < package.toml | jq -r ".dependencies[].image | select( . != null ) | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
 
                   update-package-dependency \
                     --buildpack-toml buildpack.toml \

--- a/.github/workflows/update-spring-boot.yml
+++ b/.github/workflows/update-spring-boot.yml
@@ -62,7 +62,7 @@ jobs:
                 NEW_VERSION=$(crane ls "${DEPENDENCY}" | grep -v latest | sort -V | tail -n 1)
 
                 if [[ -e builder.toml ]]; then
-                  OLD_VERSION=$(yj -tj < builder.toml | jq -r ".buildpacks[].image | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
+                  OLD_VERSION=$(yj -tj < builder.toml | jq -r ".buildpacks[].image | select( . != null ) | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
 
                   update-package-dependency \
                     --builder-toml builder.toml \
@@ -71,7 +71,7 @@ jobs:
 
                   git add builder.toml
                 elif [[ -e package.toml ]]; then
-                  OLD_VERSION=$(yj -tj < package.toml | jq -r ".dependencies[].image | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
+                  OLD_VERSION=$(yj -tj < package.toml | jq -r ".dependencies[].image | select( . != null ) | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
 
                   update-package-dependency \
                     --buildpack-toml buildpack.toml \


### PR DESCRIPTION
Previously the package update functionality expected all packages to be referenced as images.  However, there are still a few buildpacks that are not images and this would break the update script.  This change fixes that script to handle non-image buildpacks.
