### PR TITLE
Adds watchexec

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The Paketo Azure Java Buildpack is a Cloud Native Buildpack with an order defini
 * [`paketo-buildpacks/procfile`](https://github.com/paketo-buildpacks/procfile)
 * [`paketo-buildpacks/sbt`](https://github.com/paketo-buildpacks/sbt)
 * [`paketo-buildpacks/spring-boot`](https://github.com/paketo-buildpacks/spring-boot)
+* [`paketo-buildpacks/watchexec`](https://github.com/paketo-buildpacks/watchexec)
 
 ## License
 This buildpack is released under version 2.0 of the [Apache License][a].

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -36,6 +36,7 @@ group = [
   { id = "paketo-buildpacks/gradle",                     version="5.6.0", optional = true },
   { id = "paketo-buildpacks/maven",                      version="5.6.0", optional = true },
   { id = "paketo-buildpacks/sbt",                        version="5.5.1", optional = true },
+  { id = "paketo-buildpacks/watchexec",                  version="1.1.0", optional = true },
 
 ### Order determines precedence
   { id = "paketo-buildpacks/executable-jar",             version="5.3.0", optional = true },

--- a/package.toml
+++ b/package.toml
@@ -5,6 +5,7 @@ dependencies = [
   { uri = "docker://gcr.io/paketo-buildpacks/gradle:5.6.0" },
   { uri = "docker://gcr.io/paketo-buildpacks/maven:5.6.0" },
   { uri = "docker://gcr.io/paketo-buildpacks/sbt:5.5.1" },
+  { uri = "docker://gcr.io/paketo-buildpacks/watchexec:1.1.0" },
   { uri = "docker://gcr.io/paketo-buildpacks/executable-jar:5.3.0" },
   { uri = "docker://gcr.io/paketo-buildpacks/apache-tomcat:6.3.0" },
   { uri = "docker://gcr.io/paketo-buildpacks/dist-zip:4.2.1" },


### PR DESCRIPTION
## Summary
It needs to be included prior to executable-jar and dist-zip which may optionally require watchexec. A requires must be provided before the buildpack requiring it.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
