### PR TITLE
Implement RFC 0050: Rename Buildpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # `gcr.io/paketo-buildpacks/java-azure`
 
-The Paketo Azure Java Buildpack is a Cloud Native Buildpack with an order definition suitable for Java applications on Azure.
+The Paketo Buildpack for Azure Java is a Cloud Native Buildpack with an order definition suitable for Java applications on Azure.
 
 ## Included Buildpacks
 

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -19,7 +19,7 @@ api = "0.7"
   homepage = "https://paketo.io/docs/howto/java/"
   id = "paketo-buildpacks/java-azure"
   keywords = ["java", "composite", "azure"]
-  name = "Paketo Azure Java Buildpack"
+  name = "Paketo Buildpack for Azure Java"
   version = "{{.version}}"
 
   [[buildpack.licenses]]


### PR DESCRIPTION
Renames 'Paketo Azure Java Buildpack' to 'Paketo Buildpack for Azure Java'.

Implements RFC 0050, https://github.com/paketo-buildpacks/rfcs/issues/233, for this buildpack.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
