### PR TITLE
Adds NodeEngine & Yarn buildpacks as optional

### DIFF
--- a/.github/workflows/pb-update-node-engine.yml
+++ b/.github/workflows/pb-update-node-engine.yml
@@ -1,0 +1,141 @@
+name: Update node-engine
+"on":
+    schedule:
+        - cron: 0 4 * * 4-5
+    workflow_dispatch: {}
+jobs:
+    update:
+        name: Update Package Dependency
+        runs-on:
+            - ubuntu-latest
+        steps:
+            - name: Docker login gcr.io
+              if: ${{ (github.event_name != 'pull_request' || ! github.event.pull_request.head.repo.fork) && (github.actor != 'dependabot[bot]') }}
+              uses: docker/login-action@v2
+              with:
+                password: ${{ secrets.GCR_PUSH_BOT_JSON_KEY }}
+                registry: gcr.io
+                username: _json_key
+            - name: Docker login docker.io
+              if: ${{ (github.event_name != 'pull_request' || ! github.event.pull_request.head.repo.fork) && (github.actor != 'dependabot[bot]') }}
+              uses: docker/login-action@v2
+              with:
+                password: ${{ secrets.PAKETO_BUILDPACKS_DOCKERHUB_PASSWORD }}
+                registry: docker.io
+                username: ${{ secrets.PAKETO_BUILDPACKS_DOCKERHUB_USERNAME }}
+            - uses: actions/setup-go@v3
+              with:
+                go-version: "1.18"
+            - name: Install update-package-dependency
+              run: |
+                #!/usr/bin/env bash
+
+                set -euo pipefail
+
+                go install -ldflags="-s -w" github.com/paketo-buildpacks/libpak/cmd/update-package-dependency@latest
+            - name: Install crane
+              run: |
+                #!/usr/bin/env bash
+
+                set -euo pipefail
+
+                echo "Installing crane ${CRANE_VERSION}"
+
+                mkdir -p "${HOME}"/bin
+                echo "${HOME}/bin" >> "${GITHUB_PATH}"
+
+                curl \
+                  --show-error \
+                  --silent \
+                  --location \
+                  "https://github.com/google/go-containerregistry/releases/download/v${CRANE_VERSION}/go-containerregistry_Linux_x86_64.tar.gz" \
+                | tar -C "${HOME}/bin" -xz crane
+              env:
+                CRANE_VERSION: 0.8.0
+            - name: Install yj
+              run: |
+                #!/usr/bin/env bash
+
+                set -euo pipefail
+
+                echo "Installing yj ${YJ_VERSION}"
+
+                mkdir -p "${HOME}"/bin
+                echo "${HOME}/bin" >> "${GITHUB_PATH}"
+
+                curl \
+                  --location \
+                  --show-error \
+                  --silent \
+                  --output "${HOME}"/bin/yj \
+                  "https://github.com/sclevine/yj/releases/download/v${YJ_VERSION}/yj-linux"
+
+                chmod +x "${HOME}"/bin/yj
+              env:
+                YJ_VERSION: 5.0.0
+            - uses: actions/checkout@v3
+            - name: Update Package Dependency
+              id: package
+              run: |
+                #!/usr/bin/env bash
+
+                set -euo pipefail
+
+                NEW_VERSION=$(crane ls "${DEPENDENCY}" | grep -v latest | sort -V | tail -n 1)
+
+                if [[ -e builder.toml ]]; then
+                  OLD_VERSION=$(yj -tj < builder.toml | jq -r ".buildpacks[].uri | capture(\".*${DEPENDENCY}:(?<version>.+)\") | .version")
+
+                  update-package-dependency \
+                    --builder-toml builder.toml \
+                    --id "${DEPENDENCY}" \
+                    --version "${NEW_VERSION}"
+
+                  git add builder.toml
+                fi
+
+                if [[ -e package.toml ]]; then
+                  OLD_VERSION=$(yj -tj < package.toml | jq -r ".dependencies[].uri | capture(\".*${DEPENDENCY}:(?<version>.+)\") | .version")
+
+                  update-package-dependency \
+                    --buildpack-toml buildpack.toml \
+                    --id "${BP_DEPENDENCY:-$DEPENDENCY}" \
+                    --version "${NEW_VERSION}"
+
+                  update-package-dependency \
+                    --package-toml package.toml \
+                    --id "${PKG_DEPENDENCY:-$DEPENDENCY}" \
+                    --version "${NEW_VERSION}"
+
+                  git add buildpack.toml package.toml
+                fi
+
+                git checkout -- .
+
+                if [ "$(echo "$OLD_VERSION" | awk -F '.' '{print $1}')" != "$(echo "$NEW_VERSION" | awk -F '.' '{print $1}')" ]; then
+                  LABEL="semver:major"
+                elif [ "$(echo "$OLD_VERSION" | awk -F '.' '{print $2}')" != "$(echo "$NEW_VERSION" | awk -F '.' '{print $2}')" ]; then
+                  LABEL="semver:minor"
+                else
+                  LABEL="semver:patch"
+                fi
+
+                echo "old-version=${OLD_VERSION}" >> "$GITHUB_OUTPUT"
+                echo "new-version=${NEW_VERSION}" >> "$GITHUB_OUTPUT"
+                echo "version-label=${LABEL}" >> "$GITHUB_OUTPUT"
+              env:
+                DEPENDENCY: gcr.io/paketo-buildpacks/node-engine
+            - uses: peter-evans/create-pull-request@v4
+              with:
+                author: ${{ secrets.JAVA_GITHUB_USERNAME }} <${{ secrets.JAVA_GITHUB_USERNAME }}@users.noreply.github.com>
+                body: Bumps [`gcr.io/paketo-buildpacks/node-engine`](https://gcr.io/paketo-buildpacks/node-engine) from [`${{ steps.package.outputs.old-version }}`](https://gcr.io/paketo-buildpacks/node-engine:${{ steps.package.outputs.old-version }}) to [`${{ steps.package.outputs.new-version }}`](https://gcr.io/paketo-buildpacks/node-engine:${{ steps.package.outputs.new-version }}).
+                branch: update/package/node-engine
+                commit-message: |-
+                    Bump gcr.io/paketo-buildpacks/node-engine from ${{ steps.package.outputs.old-version }} to ${{ steps.package.outputs.new-version }}
+
+                    Bumps gcr.io/paketo-buildpacks/node-engine from ${{ steps.package.outputs.old-version }} to ${{ steps.package.outputs.new-version }}.
+                delete-branch: true
+                labels: ${{ steps.package.outputs.version-label }}, type:dependency-upgrade
+                signoff: true
+                title: Bump gcr.io/paketo-buildpacks/node-engine from ${{ steps.package.outputs.old-version }} to ${{ steps.package.outputs.new-version }}
+                token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/pb-update-yarn.yml
+++ b/.github/workflows/pb-update-yarn.yml
@@ -1,0 +1,141 @@
+name: Update yarn
+"on":
+    schedule:
+        - cron: 0 4 * * 4-5
+    workflow_dispatch: {}
+jobs:
+    update:
+        name: Update Package Dependency
+        runs-on:
+            - ubuntu-latest
+        steps:
+            - name: Docker login gcr.io
+              if: ${{ (github.event_name != 'pull_request' || ! github.event.pull_request.head.repo.fork) && (github.actor != 'dependabot[bot]') }}
+              uses: docker/login-action@v2
+              with:
+                password: ${{ secrets.GCR_PUSH_BOT_JSON_KEY }}
+                registry: gcr.io
+                username: _json_key
+            - name: Docker login docker.io
+              if: ${{ (github.event_name != 'pull_request' || ! github.event.pull_request.head.repo.fork) && (github.actor != 'dependabot[bot]') }}
+              uses: docker/login-action@v2
+              with:
+                password: ${{ secrets.PAKETO_BUILDPACKS_DOCKERHUB_PASSWORD }}
+                registry: docker.io
+                username: ${{ secrets.PAKETO_BUILDPACKS_DOCKERHUB_USERNAME }}
+            - uses: actions/setup-go@v3
+              with:
+                go-version: "1.18"
+            - name: Install update-package-dependency
+              run: |
+                #!/usr/bin/env bash
+
+                set -euo pipefail
+
+                go install -ldflags="-s -w" github.com/paketo-buildpacks/libpak/cmd/update-package-dependency@latest
+            - name: Install crane
+              run: |
+                #!/usr/bin/env bash
+
+                set -euo pipefail
+
+                echo "Installing crane ${CRANE_VERSION}"
+
+                mkdir -p "${HOME}"/bin
+                echo "${HOME}/bin" >> "${GITHUB_PATH}"
+
+                curl \
+                  --show-error \
+                  --silent \
+                  --location \
+                  "https://github.com/google/go-containerregistry/releases/download/v${CRANE_VERSION}/go-containerregistry_Linux_x86_64.tar.gz" \
+                | tar -C "${HOME}/bin" -xz crane
+              env:
+                CRANE_VERSION: 0.8.0
+            - name: Install yj
+              run: |
+                #!/usr/bin/env bash
+
+                set -euo pipefail
+
+                echo "Installing yj ${YJ_VERSION}"
+
+                mkdir -p "${HOME}"/bin
+                echo "${HOME}/bin" >> "${GITHUB_PATH}"
+
+                curl \
+                  --location \
+                  --show-error \
+                  --silent \
+                  --output "${HOME}"/bin/yj \
+                  "https://github.com/sclevine/yj/releases/download/v${YJ_VERSION}/yj-linux"
+
+                chmod +x "${HOME}"/bin/yj
+              env:
+                YJ_VERSION: 5.0.0
+            - uses: actions/checkout@v3
+            - name: Update Package Dependency
+              id: package
+              run: |
+                #!/usr/bin/env bash
+
+                set -euo pipefail
+
+                NEW_VERSION=$(crane ls "${DEPENDENCY}" | grep -v latest | sort -V | tail -n 1)
+
+                if [[ -e builder.toml ]]; then
+                  OLD_VERSION=$(yj -tj < builder.toml | jq -r ".buildpacks[].uri | capture(\".*${DEPENDENCY}:(?<version>.+)\") | .version")
+
+                  update-package-dependency \
+                    --builder-toml builder.toml \
+                    --id "${DEPENDENCY}" \
+                    --version "${NEW_VERSION}"
+
+                  git add builder.toml
+                fi
+
+                if [[ -e package.toml ]]; then
+                  OLD_VERSION=$(yj -tj < package.toml | jq -r ".dependencies[].uri | capture(\".*${DEPENDENCY}:(?<version>.+)\") | .version")
+
+                  update-package-dependency \
+                    --buildpack-toml buildpack.toml \
+                    --id "${BP_DEPENDENCY:-$DEPENDENCY}" \
+                    --version "${NEW_VERSION}"
+
+                  update-package-dependency \
+                    --package-toml package.toml \
+                    --id "${PKG_DEPENDENCY:-$DEPENDENCY}" \
+                    --version "${NEW_VERSION}"
+
+                  git add buildpack.toml package.toml
+                fi
+
+                git checkout -- .
+
+                if [ "$(echo "$OLD_VERSION" | awk -F '.' '{print $1}')" != "$(echo "$NEW_VERSION" | awk -F '.' '{print $1}')" ]; then
+                  LABEL="semver:major"
+                elif [ "$(echo "$OLD_VERSION" | awk -F '.' '{print $2}')" != "$(echo "$NEW_VERSION" | awk -F '.' '{print $2}')" ]; then
+                  LABEL="semver:minor"
+                else
+                  LABEL="semver:patch"
+                fi
+
+                echo "old-version=${OLD_VERSION}" >> "$GITHUB_OUTPUT"
+                echo "new-version=${NEW_VERSION}" >> "$GITHUB_OUTPUT"
+                echo "version-label=${LABEL}" >> "$GITHUB_OUTPUT"
+              env:
+                DEPENDENCY: gcr.io/paketo-buildpacks/yarn
+            - uses: peter-evans/create-pull-request@v4
+              with:
+                author: ${{ secrets.JAVA_GITHUB_USERNAME }} <${{ secrets.JAVA_GITHUB_USERNAME }}@users.noreply.github.com>
+                body: Bumps [`gcr.io/paketo-buildpacks/yarn`](https://gcr.io/paketo-buildpacks/yarn) from [`${{ steps.package.outputs.old-version }}`](https://gcr.io/paketo-buildpacks/yarn:${{ steps.package.outputs.old-version }}) to [`${{ steps.package.outputs.new-version }}`](https://gcr.io/paketo-buildpacks/yarn:${{ steps.package.outputs.new-version }}).
+                branch: update/package/yarn
+                commit-message: |-
+                    Bump gcr.io/paketo-buildpacks/yarn from ${{ steps.package.outputs.old-version }} to ${{ steps.package.outputs.new-version }}
+
+                    Bumps gcr.io/paketo-buildpacks/yarn from ${{ steps.package.outputs.old-version }} to ${{ steps.package.outputs.new-version }}.
+                delete-branch: true
+                labels: ${{ steps.package.outputs.version-label }}, type:dependency-upgrade
+                signoff: true
+                title: Bump gcr.io/paketo-buildpacks/yarn from ${{ steps.package.outputs.old-version }} to ${{ steps.package.outputs.new-version }}
+                token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -22,11 +22,13 @@ The Paketo Buildpack for Azure Java is a Cloud Native Buildpack with an order de
 * [`paketo-buildpacks/liberty`](https://github.com/paketo-buildpacks/liberty)
 * [`paketo-buildpacks/maven`](https://github.com/paketo-buildpacks/maven)
 * [`paketo-buildpacks/microsoft-openjdk`](https://github.com/paketo-buildpacks/microsoft-openjdk)
+* [`paketo-buildpacks/node-engine`](https://github.com/paketo-buildpacks/node-engine)
 * [`paketo-buildpacks/procfile`](https://github.com/paketo-buildpacks/procfile)
 * [`paketo-buildpacks/sbt`](https://github.com/paketo-buildpacks/sbt)
 * [`paketo-buildpacks/spring-boot`](https://github.com/paketo-buildpacks/spring-boot)
 * [`paketo-buildpacks/syft`](https://github.com/paketo-buildpacks/syft)
 * [`paketo-buildpacks/watchexec`](https://github.com/paketo-buildpacks/watchexec)
+* [`paketo-buildpacks/yarn`](https://github.com/paketo-buildpacks/yarn)
 
 ## License
 

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -41,6 +41,16 @@ api = "0.7"
     version = "2.8.1"
 
   [[order.group]]
+    id = "paketo-buildpacks/yarn"
+    optional = true
+    version = "1.0.0"
+
+  [[order.group]]
+    id = "paketo-buildpacks/node-engine"
+    optional = true
+    version = "1.1.0"
+
+  [[order.group]]
     id = "paketo-buildpacks/syft"
     optional = true
     version = "1.25.0"

--- a/package.toml
+++ b/package.toml
@@ -6,6 +6,12 @@
   uri = "docker://gcr.io/paketo-buildpacks/microsoft-openjdk:2.8.1"
 
 [[dependencies]]
+  uri = "docker://gcr.io/paketo-buildpacks/yarn:1.0.0"
+
+[[dependencies]]
+  uri = "docker://gcr.io/paketo-buildpacks/node-engine:1.1.0"
+
+[[dependencies]]
   uri = "docker://gcr.io/paketo-buildpacks/syft:1.25.0"
 
 [[dependencies]]


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
Adds support for Node & Yarn supplying buildpacks to order group as optional, as per in Java: https://github.com/paketo-buildpacks/java/pull/913

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
